### PR TITLE
KashiwaYukina.pm中のgraduate_dateとjoin_dateとの入れ違い

### DIFF
--- a/lib/Acme/MomoiroClover/Members/KashiwaYukina.pm
+++ b/lib/Acme/MomoiroClover/Members/KashiwaYukina.pm
@@ -16,8 +16,8 @@ sub info {
         blood_type     => 'B',
         hometown       => '神奈川県',
         emoticon       => [],
-        graduate_date  => Date::Simple->new('2008-11-23'),
-        join_date      => Date::Simple->new('2009-03-09'),
+        graduate_date  => Date::Simple->new('2009-03-09'),
+        join_date      => Date::Simple->new('2008-11-23'),
         color          => undef,
     );
 }


### PR DESCRIPTION
I found (graduate_date < join_date) definition in Members/KashiwaYukina.pm.
        graduate_date  => Date::Simple->new('2008-11-23'),
        join_date      => Date::Simple->new('2009-03-09'),

Fixed in fix-yukina-joindate branch:
        graduate_date  => Date::Simple->new('2009-03-09'),
        join_date      => Date::Simple->new('2008-11-23'),
